### PR TITLE
fix: Kernel build dependency chain

### DIFF
--- a/recipes-kernel/linux/linux-tegra_4.9.bb
+++ b/recipes-kernel/linux/linux-tegra_4.9.bb
@@ -14,6 +14,15 @@ DEPENDS:remove = "kern-tools-native"
 DEPENDS:append = " kern-tools-tegra-native"
 DEPENDS:append = "${@' wireless-regdb-native' if bb.utils.to_boolean(d.getVar('KERNEL_INTERNAL_WIRELESS_REGDB')) else ''}"
 
+# kernel-yocto.bbclass hardcodes task-level [depends] on kern-tools-native.
+# Since we swap kern-tools-native for kern-tools-tegra-native via DEPENDS above,
+# we must also update the task [depends] flags — DEPENDS only feeds
+# do_prepare_recipe_sysroot, which has no ordering guarantee relative to these tasks.
+do_kernel_metadata[depends] = "kern-tools-tegra-native:do_populate_sysroot"
+do_validate_branches[depends] = "kern-tools-tegra-native:do_populate_sysroot"
+do_kernel_configme[depends] = "kern-tools-tegra-native:do_populate_sysroot"
+do_config_analysis[depends] = "kern-tools-tegra-native:do_populate_sysroot"
+
 LINUX_VERSION ?= "4.9.337"
 PV = "${LINUX_VERSION}+git${SRCPV}"
 FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}-${@bb.parse.vars_from_file(d.getVar('FILE', False),d)[1]}:"


### PR DESCRIPTION
### Why
do_kernel_metadata can run before kern-tools-tegra-native which it depends on for artifacts that the latter generates.

There was a race condition for building the kernel. The tegra kernel recipe inherited the DEPENDS but not the task-level depends from the kernel-yocto.bbclass recipe. So tasks like do_kernel_metadata could run in parallel with do_prepare_recipe_sysroot (which uses the DEPENDS dependencies) and could then fail since it needs files populated by kern-tools-tegra-native:do_populate_sysroot which is only in the linux-tegra -> do_prepare_recipe_sysroot dependency chain.

This race condition doesn't seem to occur frequently on vc2 or on vc3 dev and ssh builds. Or on local prod builds. But on the new fast build server it's reliably reproduced on vc3 prod builds.

### What
Add kern-tools-tegra-native:do_populate_sysroot to dependency graph of linux-tegra task that need it for linux-tegra and linux-tegra-initrd-flash.