### PR TITLE
fix(gcc-linaro-baremetal): fetch toolchain from ARM CDN

### DIFF
--- a/recipes-devtools/gcc-linaro-baremetal/gcc-linaro-baremetal-arm-native_7.4.1-2019.02.bb
+++ b/recipes-devtools/gcc-linaro-baremetal/gcc-linaro-baremetal-arm-native_7.4.1-2019.02.bb
@@ -4,7 +4,7 @@ LICENSE = "GPL-3.0-with-GCC-exception & LGPL-3.0-only & GPL-3.0-only & GFDL-1.3"
 SECTION = "devel"
 
 BASEVER = "${@'.'.join(d.getVar('PV').split('.')[0:2]) + '-' + d.getVar('PV').split('-')[1]}"
-SRC_URI = "https://releases.linaro.org/components/toolchain/binaries/${BASEVER}/arm-eabi/gcc-linaro-${PV}-x86_64_arm-eabi.tar.xz"
+SRC_URI = "https://developer.arm.com/-/cdn-downloads/permalink/legacy-linaro-gnu-toolchains/${BASEVER}/gcc-linaro-${PV}-x86_64_arm-eabi.tar.xz"
 SRC_URI[md5sum] = "0a8e5b7b67d713ece5fe24b120393b03"
 SRC_URI[sha256sum] = "d4ae43bd325f3a8df2bcfcc1909c1c28356e1e9f5705e21790b17c68830733d7"
 


### PR DESCRIPTION
### Why

`releases.linaro.org` no longer serves the 7.4-2019.02 arm-eabi
toolchain tarball, so `do_fetch` fails with wget exit code 4 and breaks
the build.

### What

Point `SRC_URI` at the `developer.arm.com` legacy-toolchain permalink.
Checksums unchanged.